### PR TITLE
feat(#5): 상품 이미지 업로드 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1")
+    implementation "io.awspring.cloud:spring-cloud-aws-starter-s3"
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/ddoddo/backend/config/S3Config.java
+++ b/backend/src/main/java/com/ddoddo/backend/config/S3Config.java
@@ -1,0 +1,44 @@
+// src/main/java/com/ddoddo/backend/config/S3Config.java
+
+package com.ddoddo.backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+import java.net.URI;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.s3.endpoint}")
+    private String endpoint;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .endpointOverride(URI.create(endpoint)) // S3 호환 엔드포인트 지정
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true) // 경로 스타일 접근 활성화
+                        .build())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/ddoddo/backend/controller/ProductController.java
+++ b/backend/src/main/java/com/ddoddo/backend/controller/ProductController.java
@@ -68,13 +68,16 @@ public class ProductController {
     /**
      * 상품 수정
      */
-    @PatchMapping("/{productId}")
+    @PatchMapping(value = "/{productId}", consumes = {"multipart/form-data"})
     public ResponseEntity<ProductResponse> updateProduct(
             @PathVariable Long productId,
-            @RequestBody ProductUpdateRequest request,
-            @AuthenticationPrincipal Jwt jwt) {
+            @RequestPart("request") ProductUpdateRequest request,
+            @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages,
+            @RequestPart(value = "deleteImageIds", required = false) List<Long> deleteImageIds,
+            @AuthenticationPrincipal Jwt jwt) throws IOException {
+
         String uid = jwt.getSubject();
-        ProductResponse response = productService.updateProduct(productId, request, uid);
+        ProductResponse response = productService.updateProduct(productId, request, newImages, deleteImageIds, uid);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/ddoddo/backend/controller/ProductController.java
+++ b/backend/src/main/java/com/ddoddo/backend/controller/ProductController.java
@@ -73,11 +73,11 @@ public class ProductController {
             @PathVariable Long productId,
             @RequestPart("request") ProductUpdateRequest request,
             @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages,
-            @RequestPart(value = "deleteImageIds", required = false) List<Long> deleteImageIds,
             @AuthenticationPrincipal Jwt jwt) throws IOException {
 
         String uid = jwt.getSubject();
-        ProductResponse response = productService.updateProduct(productId, request, newImages, deleteImageIds, uid);
+
+        ProductResponse response = productService.updateProduct(productId, request, newImages, uid);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/ddoddo/backend/controller/ProductController.java
+++ b/backend/src/main/java/com/ddoddo/backend/controller/ProductController.java
@@ -10,7 +10,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -20,17 +22,30 @@ public class ProductController {
 
     private final ProductService productService;
 
+
     /**
      * 상품 등록
      */
-    @PostMapping
+    @PostMapping(consumes = {"multipart/form-data"}) // multipart/form-data 형식 명시
     public ResponseEntity<ProductResponse> createProduct(
-            @RequestBody ProductCreateRequest request,
-            @AuthenticationPrincipal Jwt jwt) {
+            @RequestPart("request") ProductCreateRequest request, // @RequestBody -> @RequestPart
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            @AuthenticationPrincipal Jwt jwt) throws IOException {
         String uid = jwt.getSubject();
-        ProductResponse response = productService.createProduct(request, uid);
+        ProductResponse response = productService.createProduct(request, images, uid);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
+//    /**
+//     * 상품 등록
+//     */
+//    @PostMapping
+//    public ResponseEntity<ProductResponse> createProduct(
+//            @RequestBody ProductCreateRequest request,
+//            @AuthenticationPrincipal Jwt jwt) {
+//        String uid = jwt.getSubject();
+//        ProductResponse response = productService.createProduct(request, uid);
+//        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+//    }
 
     /**
      * 상품 상세 조회

--- a/backend/src/main/java/com/ddoddo/backend/domain/Product.java
+++ b/backend/src/main/java/com/ddoddo/backend/domain/Product.java
@@ -42,6 +42,7 @@ public class Product {
     private User user;
 
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("displayOrder ASC")
     private List<ProductImage> images = new ArrayList<>();
 
     @Builder

--- a/backend/src/main/java/com/ddoddo/backend/domain/Product.java
+++ b/backend/src/main/java/com/ddoddo/backend/domain/Product.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "products")
@@ -39,6 +41,9 @@ public class Product {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProductImage> images = new ArrayList<>();
+
     @Builder
     public Product(String title, String content, Integer price, User user) {
         this.title = title;
@@ -47,6 +52,12 @@ public class Product {
         this.status = ProductStatus.FOR_SALE;
         this.user = user;
         this.createdAt = LocalDateTime.now();
+    }
+
+    // 연관관계 편의 메서드
+    public void addImage(ProductImage image) {
+        images.add(image);
+        image.setProduct(this);
     }
 
     public void update(String title, String content, Integer price, ProductStatus status) {

--- a/backend/src/main/java/com/ddoddo/backend/domain/ProductImage.java
+++ b/backend/src/main/java/com/ddoddo/backend/domain/ProductImage.java
@@ -1,0 +1,29 @@
+package com.ddoddo.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "product_images")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Builder
+    public ProductImage(String imageUrl, Product product) {
+        this.imageUrl = imageUrl;
+        this.product = product;
+    }
+}

--- a/backend/src/main/java/com/ddoddo/backend/domain/ProductImage.java
+++ b/backend/src/main/java/com/ddoddo/backend/domain/ProductImage.java
@@ -17,13 +17,17 @@ public class ProductImage {
     @Column(nullable = false)
     private String imageUrl;
 
+    @Column(nullable = false, columnDefinition = "INT DEFAULT 0")
+    private int displayOrder; // 순서 저장 필드
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
 
     @Builder
-    public ProductImage(String imageUrl, Product product) {
+    public ProductImage(String imageUrl, Product product, int displayOrder) {
         this.imageUrl = imageUrl;
         this.product = product;
+        this.displayOrder = displayOrder;
     }
 }

--- a/backend/src/main/java/com/ddoddo/backend/domain/ProductImage.java
+++ b/backend/src/main/java/com/ddoddo/backend/domain/ProductImage.java
@@ -17,7 +17,7 @@ public class ProductImage {
     @Column(nullable = false)
     private String imageUrl;
 
-    @Column(nullable = false, columnDefinition = "INT DEFAULT 0")
+    @Column(nullable = false)
     private int displayOrder; // 순서 저장 필드
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/ddoddo/backend/dto/product/ProductImageResponse.java
+++ b/backend/src/main/java/com/ddoddo/backend/dto/product/ProductImageResponse.java
@@ -1,0 +1,21 @@
+package com.ddoddo.backend.dto.product;
+
+import com.ddoddo.backend.domain.ProductImage;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProductImageResponse {
+    private Long id;
+    private String imageUrl;
+    private int displayOrder;
+
+    public static ProductImageResponse from(ProductImage productImage) {
+        return ProductImageResponse.builder()
+                .id(productImage.getId())
+                .imageUrl(productImage.getImageUrl())
+                .displayOrder(productImage.getDisplayOrder())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/ddoddo/backend/dto/product/ProductResponse.java
+++ b/backend/src/main/java/com/ddoddo/backend/dto/product/ProductResponse.java
@@ -6,6 +6,9 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -17,13 +20,23 @@ public class ProductResponse {
     private ProductStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    
+
     // 작성자 정보
     private String userUid;
     private String userNickname;
     private String userProfileImageUrl;
-    
+
+    // 추가된 이미지 목록 필드
+    private List<ProductImageResponse> images;
+
     public static ProductResponse from(Product product) {
+        // 이미지가 null일 경우를 대비하여 안전하게 처리
+        List<ProductImageResponse> imageResponses = product.getImages() != null
+                ? product.getImages().stream()
+                .map(ProductImageResponse::from)
+                .collect(Collectors.toList())
+                : Collections.emptyList();
+
         return ProductResponse.builder()
                 .id(product.getId())
                 .title(product.getTitle())
@@ -35,6 +48,7 @@ public class ProductResponse {
                 .userUid(product.getUser().getUid())
                 .userNickname(product.getUser().getNickname())
                 .userProfileImageUrl(product.getUser().getProfileImageUrl())
+                .images(imageResponses) // 빌더에 이미지 목록 추가
                 .build();
     }
-} 
+}

--- a/backend/src/main/java/com/ddoddo/backend/dto/product/ProductUpdateRequest.java
+++ b/backend/src/main/java/com/ddoddo/backend/dto/product/ProductUpdateRequest.java
@@ -4,6 +4,8 @@ import com.ddoddo.backend.domain.ProductStatus;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 public class ProductUpdateRequest {
@@ -11,4 +13,5 @@ public class ProductUpdateRequest {
     private String content;
     private Integer price;
     private ProductStatus status;
+    private List<Long> deleteImageIds;
 } 

--- a/backend/src/main/java/com/ddoddo/backend/repository/ProductRepository.java
+++ b/backend/src/main/java/com/ddoddo/backend/repository/ProductRepository.java
@@ -2,8 +2,14 @@ package com.ddoddo.backend.repository;
 
 import com.ddoddo.backend.domain.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    @Query("select p from Product p left join fetch p.images where p.id = :id")
+    Optional<Product> findByIdWithImages(@Param("id") Long id);
 } 

--- a/backend/src/main/java/com/ddoddo/backend/service/ProductService.java
+++ b/backend/src/main/java/com/ddoddo/backend/service/ProductService.java
@@ -44,9 +44,15 @@ public class ProductService {
                 .build();
 
         if (images != null && !images.isEmpty()) {
-            for (MultipartFile file : images) {
+            for (int i = 0; i < images.size(); i++) {
+                MultipartFile file = images.get(i);
                 String imageUrl = s3UploadService.upload(file, "product-images");
-                product.addImage(ProductImage.builder().imageUrl(imageUrl).product(product).build());
+                // 빌더에 displayOrder 추가
+                product.addImage(ProductImage.builder()
+                        .imageUrl(imageUrl)
+                        .product(product)
+                        .displayOrder(i) // 리스트의 인덱스를 순서로 저장
+                        .build());
             }
         }
 

--- a/backend/src/main/java/com/ddoddo/backend/service/ProductService.java
+++ b/backend/src/main/java/com/ddoddo/backend/service/ProductService.java
@@ -101,8 +101,7 @@ public class ProductService {
      */
     @Transactional
     public ProductResponse updateProduct(Long productId, ProductUpdateRequest request,
-                                         List<MultipartFile> newImages, List<Long> deleteImageIds, String uid) throws IOException {
-
+                                         List<MultipartFile> newImages, String uid) throws IOException {
         Product product = productRepository.findByIdWithImages(productId)
                 .orElseThrow(() -> new EntityNotFoundException("상품을 찾을 수 없습니다."));
 
@@ -114,7 +113,10 @@ public class ProductService {
         // 1. 텍스트 정보 업데이트
         product.update(request.getTitle(), request.getContent(), request.getPrice(), request.getStatus());
 
+
         // 2. 기존 이미지 삭제
+        List<Long> deleteImageIds = request.getDeleteImageIds();
+
         if (deleteImageIds != null && !deleteImageIds.isEmpty()) {
             List<ProductImage> imagesToDelete = product.getImages().stream()
                     .filter(img -> deleteImageIds.contains(img.getId()))

--- a/backend/src/main/java/com/ddoddo/backend/service/S3UploadService.java
+++ b/backend/src/main/java/com/ddoddo/backend/service/S3UploadService.java
@@ -7,11 +7,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.UUID;
 
 @Slf4j
@@ -45,5 +47,23 @@ public class S3UploadService {
                 .build();
 
         return s3Client.utilities().getUrl(getUrlRequest).toString();
+    }
+
+    public void deleteImage(String fileUrl) {
+        try {
+            // 전체 URL에서 객체 키(파일 경로)를 추출
+            URI uri = new URI(fileUrl);
+            String key = uri.getPath().substring(1); // 맨 앞의 '/' 제거
+
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("R2에서 파일 삭제 성공: {}", key);
+        } catch (Exception e) {
+            log.error("R2 파일 삭제 실패: {}", fileUrl, e);
+        }
     }
 }

--- a/backend/src/main/java/com/ddoddo/backend/service/S3UploadService.java
+++ b/backend/src/main/java/com/ddoddo/backend/service/S3UploadService.java
@@ -14,6 +14,7 @@ import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URL;
 import java.util.UUID;
 
 @Slf4j
@@ -51,9 +52,12 @@ public class S3UploadService {
 
     public void deleteImage(String fileUrl) {
         try {
-            // 전체 URL에서 객체 키(파일 경로)를 추출
-            URI uri = new URI(fileUrl);
-            String key = uri.getPath().substring(1); // 맨 앞의 '/' 제거
+            // 1. 전체 URL에서 경로(/<버킷이름>/<파일경로>)를 추출합니다.
+            String path = new URL(fileUrl).getPath();
+
+            // 2. 경로의 맨 앞 '/'와 버킷 이름을 제거하여 순수한 파일 키만 남깁니다.
+            // 예: "/ddoddo-market-images/product-images/abc.png" -> "product-images/abc.png"
+            String key = path.substring(bucket.length() + 2); // 슬래시 2개(/, /)만큼 추가로 잘라냅니다.
 
             DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
                     .bucket(bucket)
@@ -63,7 +67,7 @@ public class S3UploadService {
             s3Client.deleteObject(deleteObjectRequest);
             log.info("R2에서 파일 삭제 성공: {}", key);
         } catch (Exception e) {
-            log.error("R2 파일 삭제 실패: {}", fileUrl, e);
+            log.error("R2 파일 삭제 실패. URL: {}, 에러: {}", fileUrl, e.getMessage());
         }
     }
 }

--- a/backend/src/main/java/com/ddoddo/backend/service/S3UploadService.java
+++ b/backend/src/main/java/com/ddoddo/backend/service/S3UploadService.java
@@ -1,0 +1,49 @@
+package com.ddoddo.backend.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3UploadService {
+
+    private final S3Client s3Client; // AmazonS3Client -> S3Client (v2)
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String upload(MultipartFile multipartFile, String dirName) throws IOException {
+        String originalFilename = multipartFile.getOriginalFilename();
+        String s3FileName = dirName + "/" + UUID.randomUUID() + "_" + originalFilename;
+
+        // PutObjectRequest (v2)
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3FileName)
+                .acl(ObjectCannedACL.PUBLIC_READ) // ACL 설정
+                .build();
+
+        // RequestBody (v2)
+        s3Client.putObject(putObjectRequest, RequestBody.fromBytes(multipartFile.getBytes()));
+
+        // GetUrlRequest (v2)
+        GetUrlRequest getUrlRequest = GetUrlRequest.builder()
+                .bucket(bucket)
+                .key(s3FileName)
+                .build();
+
+        return s3Client.utilities().getUrl(getUrlRequest).toString();
+    }
+}

--- a/backend/src/main/java/com/ddoddo/backend/service/S3UploadService.java
+++ b/backend/src/main/java/com/ddoddo/backend/service/S3UploadService.java
@@ -3,6 +3,7 @@ package com.ddoddo.backend.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -13,8 +14,8 @@ import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URL;
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -24,10 +25,24 @@ public class S3UploadService {
 
     private final S3Client s3Client; // AmazonS3Client -> S3Client (v2)
 
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 예: 5MB
+
+    // 허용할 이미지 Content-Type 목록을 상수로 정의합니다.
+    private static final List<String> ALLOWED_IMAGE_TYPES = List.of(
+            MediaType.IMAGE_JPEG_VALUE, // "image/jpeg"
+            MediaType.IMAGE_PNG_VALUE,  // "image/png"
+            MediaType.IMAGE_GIF_VALUE,  // "image/gif"
+            "image/webp"                // WebP 추가
+    );
+
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+
     public String upload(MultipartFile multipartFile, String dirName) throws IOException {
+        // 파일 확장자 및 크기 검증
+        validateFile(multipartFile);
+
         String originalFilename = multipartFile.getOriginalFilename();
         String s3FileName = dirName + "/" + UUID.randomUUID() + "_" + originalFilename;
 
@@ -50,6 +65,22 @@ public class S3UploadService {
         return s3Client.utilities().getUrl(getUrlRequest).toString();
     }
 
+    private void validateFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("빈 파일은 업로드할 수 없습니다.");
+        }
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new IllegalArgumentException("파일 크기는 5MB를 초과할 수 없습니다.");
+        }
+
+        String contentType = file.getContentType();
+
+        // 허용 목록에 포함되어 있는지 확인하는 로직
+        if (contentType == null || !ALLOWED_IMAGE_TYPES.contains(contentType)) {
+            throw new IllegalArgumentException("허용되지 않는 파일 형식입니다. (JPEG, PNG, GIF, WebP만 가능)");
+        }
+    }
+
     public void deleteImage(String fileUrl) {
         try {
             // 1. 전체 URL에서 경로(/<버킷이름>/<파일경로>)를 추출합니다.
@@ -70,4 +101,5 @@ public class S3UploadService {
             log.error("R2 파일 삭제 실패. URL: {}, 에러: {}", fileUrl, e.getMessage());
         }
     }
+
 }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -24,6 +24,8 @@ cloud:
     s3:
       bucket: ${CLOUDFLARE_R2_BUCKET_NAME} # 예: ddoddo-market-images
       endpoint: https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com # S3 호환 엔드포인트
+      # R2 버킷의 공개 URL
+      public-url: ${CLOUDFLARE_R2_PUBLIC_URL} # 예: https://pub-xxxxxxxx.r2.dev
     region:
       static: auto # R2는 'auto' 리전을 사용합니다.
     stack:
@@ -41,3 +43,7 @@ logging:
     org.springframework.security: DEBUG
     org.springframework.security.oauth2: DEBUG
     com.ddoddo.backend: DEBUG
+    # AWS SDK v2의 요청/응답 상세 로깅 활성화
+    software.amazon.awssdk.request: DEBUG
+    # AWS SDK가 내부적으로 사용하는 Apache HttpClient의 모든 통신 내용(wire) 로깅 활성화
+    org.apache.http.wire: DEBUG

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -15,6 +15,20 @@ spring:
       ddl-auto: update
     show-sql: true
 
+# Cloudflare R2 설정
+cloud:
+  aws:
+    credentials:
+      access-key: ${CLOUDFLARE_ACCESS_KEY_ID}
+      secret-key: ${CLOUDFLARE_SECRET_ACCESS_KEY}
+    s3:
+      bucket: ${CLOUDFLARE_R2_BUCKET_NAME} # 예: ddoddo-market-images
+      endpoint: https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com # S3 호환 엔드포인트
+    region:
+      static: auto # R2는 'auto' 리전을 사용합니다.
+    stack:
+      auto: false
+
 # CORS 전역 설정
 cors:
   allowed-origins: "http://localhost:3000" # 프론트엔드의 요청을 허용할 출처

--- a/frontend/src/app/products/[id]/edit/page.tsx
+++ b/frontend/src/app/products/[id]/edit/page.tsx
@@ -39,9 +39,37 @@ export default function EditProductPage() {
     fetchProduct();
   }, [id]);
 
-  const handleSubmit = async (data: ProductUpdateData) => {
+  const handleSubmit = async (
+    data: ProductUpdateData,
+    newImages: File[],
+    deleteImageIds: number[]
+  ) => {
+    const formData = new FormData();
+
+    // 전송할 데이터 객체에 deleteImageIds를 포함시킵니다.
+    const requestData = {
+      ...data,
+      deleteImageIds: deleteImageIds,
+    };
+
+    // 1. JSON 데이터를 Blob으로 만들어 FormData에 추가
+    formData.append(
+      "request",
+      // deleteImageIds가 포함된 객체를 JSON으로 변환합니다.
+      new Blob([JSON.stringify(requestData)], { type: "application/json" })
+    );
+
+    // 2. 새로 추가할 이미지 파일들을 FormData에 추가
+    newImages.forEach((image) => {
+      formData.append("newImages", image);
+    });
+
     try {
-      await api.patch(`/api/v1/products/${id}`, data);
+      await api.patch(`/api/v1/products/${id}`, formData, {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      });
       alert("상품 정보가 성공적으로 수정되었습니다.");
       router.push(`/products/${id}`);
     } catch (error) {

--- a/frontend/src/app/products/[id]/page.tsx
+++ b/frontend/src/app/products/[id]/page.tsx
@@ -12,24 +12,31 @@ export default function ProductDetailPage() {
   const router = useRouter();
   const { id } = params;
 
-  const { product, loading, error } = useProduct(id as string); // 커스텀 훅으로 데이터 페칭
+  const { product, loading, error } = useProduct(id as string);
   const [isOwner, setIsOwner] = useState(false);
+  
+  // ❗️ 추가: 대표 이미지 상태 관리
+  const [mainImage, setMainImage] = useState<string | null>(null);
 
   useEffect(() => {
-    // 상품 데이터나 사용자 정보가 변경될 때 소유권 확인
-    const checkOwnership = async () => {
+    const checkOwnershipAndSetImage = async () => {
       if (product) {
+        // 소유권 확인
         const supabase = createClient();
         const {
           data: { user },
         } = await supabase.auth.getUser();
-        // product.user.uid 대신 product.userUid 사용
         if (user && product.userUid === user.id) {
           setIsOwner(true);
         }
+        
+        // ❗️ 대표 이미지 초기 설정
+        if (product.images && product.images.length > 0) {
+          setMainImage(product.images[0].imageUrl);
+        }
       }
     };
-    checkOwnership();
+    checkOwnershipAndSetImage();
   }, [product]);
 
   const handleDelete = async () => {
@@ -46,43 +53,81 @@ export default function ProductDetailPage() {
 
   if (loading) return <p className="text-center mt-10">로딩 중...</p>;
   if (error) return <p className="text-center mt-10 text-red-500">{error}</p>;
-  if (!product)
-    return <p className="text-center mt-10">상품을 찾을 수 없습니다.</p>;
+  if (!product) return <p className="text-center mt-10">상품을 찾을 수 없습니다.</p>;
 
   return (
     <main className="container mx-auto p-4">
-      <div className="bg-white shadow-md rounded-lg p-6">
-        <h1 className="text-3xl font-bold mb-4">{product.title}</h1>
-        <div className="text-gray-600 mb-4">
-          {/* product.user.nickname 대신 product.userNickname 사용 */}
-          <p>판매자: {product.userNickname}</p>
-          <p>가격: {new Intl.NumberFormat("ko-KR").format(product.price)}원</p>
-          <p>상태: {product.status}</p>
-        </div>
-        <div className="prose max-w-none mb-6">
-          <p>{product.content}</p>
-        </div>
-        <div className="flex gap-4">
-          <Link href="/products">
-            <button className="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded">
-              목록으로
-            </button>
-          </Link>
-          {isOwner && (
-            <>
-              <Link href={`/products/${id}/edit`}>
-                <button className="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded">
-                  수정하기
+      <div className="bg-white shadow-md rounded-lg p-6 max-w-4xl mx-auto">
+        {/* --- 갤러리와 상품 정보가 함께 있는 섹션 --- */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {/* 왼쪽: 이미지 갤러리 */}
+          <div>
+            <div className="w-full h-96 bg-gray-200 rounded-lg overflow-hidden flex items-center justify-center mb-2">
+              <img
+                src={mainImage || "/placeholder.png"} // 이미지가 없을 경우 대비
+                alt={product.title}
+                className="w-full h-full object-cover"
+              />
+            </div>
+            {product.images && product.images.length > 1 && (
+              <div className="flex space-x-2">
+                {product.images.map((image) => (
+                  <div 
+                    key={image.id} 
+                    className="h-20 w-20 bg-gray-100 rounded-md overflow-hidden cursor-pointer border-2 hover:border-blue-500"
+                    // ❗️ 썸네일 클릭 시 대표 이미지 변경
+                    onClick={() => setMainImage(image.imageUrl)} 
+                  >
+                     <img
+                       src={image.imageUrl}
+                       alt={`상품 이미지 ${image.displayOrder + 1}`}
+                       className="w-full h-full object-cover"
+                     />
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* 오른쪽: 상품 상세 정보 및 버튼 */}
+          <div className="flex flex-col">
+            <h1 className="text-3xl font-bold mb-2">{product.title}</h1>
+            <p className="text-2xl font-semibold text-gray-800 mb-4">
+              {new Intl.NumberFormat("ko-KR").format(product.price)}원
+            </p>
+            <div className="text-sm text-gray-500 mb-4">
+                <p>판매자: {product.userNickname}</p>
+                <p>판매상태: {product.status}</p>
+            </div>
+            {/* 상세 설명 */}
+            <div className="prose max-w-none mb-6 flex-grow">
+                <p>{product.content}</p>
+            </div>
+            
+            {/* 버튼 영역 */}
+            <div className="flex gap-2 mt-auto">
+              <Link href="/products">
+                <button className="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded w-full">
+                  목록으로
                 </button>
               </Link>
-              <button
-                onClick={handleDelete}
-                className="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded"
-              >
-                삭제하기
-              </button>
-            </>
-          )}
+              {isOwner && (
+                <>
+                  <Link href={`/products/${id}/edit`} className="flex-1">
+                    <button className="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded w-full">
+                      수정하기
+                    </button>
+                  </Link>
+                  <button
+                    onClick={handleDelete}
+                    className="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded flex-1"
+                  >
+                    삭제하기
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
         </div>
       </div>
     </main>

--- a/frontend/src/app/products/new/page.tsx
+++ b/frontend/src/app/products/new/page.tsx
@@ -7,13 +7,31 @@ import api from "@/lib/api";
 export default function NewProductPage() {
   const router = useRouter();
 
-  const handleSubmit = async (data: {
-    title: string;
-    content: string;
-    price: number;
-  }) => {
+  const handleSubmit = async (
+    data: { title: string; content: string; price: number },
+    images: File[] // 추가된 이미지 파일 목록
+  ) => {
+    // FormData 객체 생성
+    const formData = new FormData();
+
+    // 1. JSON 데이터를 Blob으로 만들어 FormData에 추가
+    formData.append(
+      "request",
+      new Blob([JSON.stringify(data)], { type: "application/json" })
+    );
+
+    // 2. 이미지 파일들을 FormData에 추가
+    images.forEach((image) => {
+      formData.append("images", image);
+    });
+
     try {
-      await api.post("/api/v1/products", data);
+      // api.post 호출 시, Content-Type을 multipart/form-data로 설정
+      await api.post("/api/v1/products", formData, {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      });
       alert("상품이 성공적으로 등록되었습니다.");
       router.push("/products");
     } catch (error) {
@@ -25,6 +43,7 @@ export default function NewProductPage() {
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-3xl font-bold mb-6">새 상품 등록</h1>
+      {/* ProductForm의 onSubmit을 새로운 handleSubmit으로 전달 */}
       <ProductForm onSubmit={handleSubmit} />
     </div>
   );

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -9,15 +9,19 @@ const ProductCard = ({ product }: ProductCardProps) => {
   const formatPrice = (price: number) => {
     return new Intl.NumberFormat("ko-KR").format(price) + "원";
   };
+  
+  // 첫 번째 이미지를 가져오거나, 없으면 null
+  const representativeImage = product.images && product.images.length > 0 
+    ? product.images[0].imageUrl 
+    : null;
 
   return (
     <Link href={`/products/${product.id}`}>
       <div className="border rounded-lg overflow-hidden shadow-lg hover:shadow-xl transition-shadow duration-300 cursor-pointer">
         <div className="w-full h-48 bg-gray-200 flex items-center justify-center">
-          {/* 이미지가 있다면 <img /> 태그 사용 */}
-          {product.userProfileImageUrl ? (
+          {representativeImage ? (
             <img
-              src={product.userProfileImageUrl}
+              src={representativeImage}
               alt={product.title}
               className="w-full h-full object-cover"
             />
@@ -29,7 +33,6 @@ const ProductCard = ({ product }: ProductCardProps) => {
           <h3 className="text-lg font-semibold truncate">{product.title}</h3>
           <p className="text-gray-600 mt-1">{formatPrice(product.price)}</p>
           <div className="text-sm text-gray-500 mt-2">
-            {/* product.user.nickname 대신 product.userNickname 사용 */}
             <span>{product.userNickname}</span>
           </div>
         </div>

--- a/frontend/src/components/ProductForm.tsx
+++ b/frontend/src/components/ProductForm.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useForm, SubmitHandler } from "react-hook-form";
-import { Product } from "@/types";
+import { Product, ProductImage } from "@/types";
+import { useState } from "react";
 
+// 폼 데이터 인터페이스
 interface ProductFormData {
   title: string;
   content: string;
@@ -10,10 +12,11 @@ interface ProductFormData {
   status?: "FOR_SALE" | "RESERVED" | "SOLD_OUT";
 }
 
+// 컴포넌트 Props 인터페이스
 interface ProductFormProps {
-  onSubmit: SubmitHandler<ProductFormData>;
-  initialData?: Product; // 수정 시 초기 데이터
-  isEdit?: boolean; // 수정 모드 여부
+  onSubmit: (data: ProductFormData, images: File[], deleteImageIds: number[]) => void;
+  initialData?: Product;
+  isEdit?: boolean;
 }
 
 export default function ProductForm({
@@ -34,82 +37,102 @@ export default function ProductForm({
     },
   });
 
+  // 새로 추가될 이미지 파일 목록 상태
+  const [newImageFiles, setNewImageFiles] = useState<File[]>([]);
+  // 새로 추가될 이미지 미리보기 URL 목록 상태
+  const [newImagePreviews, setNewImagePreviews] = useState<string[]>([]);
+  // 삭제될 기존 이미지 ID 목록 상태
+  const [deleteImageIds, setDeleteImageIds] = useState<number[]>([]);
+  // 화면에 표시될 기존 이미지 목록 상태
+  const [existingImages, setExistingImages] = useState<ProductImage[]>(
+    initialData?.images || []
+  );
+
+  // 파일 선택 시 호출될 핸들러
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    setNewImageFiles((prev) => [...prev, ...files]);
+
+    const newPreviews = files.map((file) => URL.createObjectURL(file));
+    setNewImagePreviews((prev) => [...prev, ...newPreviews]);
+  };
+
+  // 새로 추가할 이미지 미리보기 삭제 핸들러
+  const handleRemoveNewImage = (index: number) => {
+    setNewImageFiles((prev) => prev.filter((_, i) => i !== index));
+    setNewImagePreviews((prev) => {
+      const newPreviews = prev.filter((_, i) => i !== index);
+      // 메모리 누수 방지를 위해 URL 객체 해제
+      URL.revokeObjectURL(prev[index]);
+      return newPreviews;
+    });
+  };
+
+  // 기존 이미지 삭제 핸들러
+  const handleRemoveExistingImage = (imageId: number) => {
+    setDeleteImageIds((prev) => [...prev, imageId]);
+    setExistingImages((prev) => prev.filter((img) => img.id !== imageId));
+  };
+
+  // 폼 제출 시 호출될 함수
+  const onFormSubmit: SubmitHandler<ProductFormData> = (data) => {
+    onSubmit(data, newImageFiles, deleteImageIds);
+  };
+
   return (
     <form
-      onSubmit={handleSubmit(onSubmit)}
-      className="space-y-4 max-w-lg mx-auto"
+      onSubmit={handleSubmit(onFormSubmit)}
+      className="space-y-6 max-w-lg mx-auto"
     >
+      {/* 상품명, 가격, 상세설명 입력 필드 (기존과 동일) */}
       <div>
-        <label
-          htmlFor="title"
-          className="block text-sm font-medium text-gray-700"
-        >
-          상품명
-        </label>
-        <input
-          id="title"
-          type="text"
-          {...register("title", { required: "상품명은 필수입니다." })}
-          className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
-        />
-        {errors.title && (
-          <p className="text-sm text-red-600 mt-1">{errors.title.message}</p>
-        )}
+        <label htmlFor="title" className="block text-sm font-medium text-gray-700">상품명</label>
+        <input id="title" type="text" {...register("title", { required: "상품명은 필수입니다." })} className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" />
+        {errors.title && <p className="text-sm text-red-600 mt-1">{errors.title.message}</p>}
+      </div>
+      <div>
+        <label htmlFor="price" className="block text-sm font-medium text-gray-700">가격</label>
+        <input id="price" type="number" {...register("price", { required: "가격은 필수입니다.", valueAsNumber: true, min: { value: 0, message: "가격은 0원 이상이어야 합니다." } })} className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" />
+        {errors.price && <p className="text-sm text-red-600 mt-1">{errors.price.message}</p>}
+      </div>
+      <div>
+        <label htmlFor="content" className="block text-sm font-medium text-gray-700">상세 설명</label>
+        <textarea id="content" rows={6} {...register("content", { required: "상세 설명은 필수입니다." })} className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" />
+        {errors.content && <p className="text-sm text-red-600 mt-1">{errors.content.message}</p>}
       </div>
 
+      {/* --- 이미지 업로드 섹션 --- */}
       <div>
-        <label
-          htmlFor="price"
-          className="block text-sm font-medium text-gray-700"
-        >
-          가격
-        </label>
-        <input
-          id="price"
-          type="number"
-          {...register("price", {
-            required: "가격은 필수입니다.",
-            valueAsNumber: true,
-            min: { value: 0, message: "가격은 0원 이상이어야 합니다." },
-          })}
-          className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
-        />
-        {errors.price && (
-          <p className="text-sm text-red-600 mt-1">{errors.price.message}</p>
-        )}
+        <label className="block text-sm font-medium text-gray-700">상품 이미지</label>
+        <div className="mt-2 flex flex-col items-center">
+            {/* 기존 이미지 미리보기 */}
+            <div className="flex flex-wrap gap-4 mb-4">
+              {existingImages.map((image) => (
+                <div key={image.id} className="relative w-24 h-24">
+                  <img src={image.imageUrl} alt="기존 이미지" className="w-full h-full object-cover rounded-md" />
+                  <button type="button" onClick={() => handleRemoveExistingImage(image.id)} className="absolute top-0 right-0 bg-red-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-xs">X</button>
+                </div>
+              ))}
+            </div>
+            {/* 새로 추가된 이미지 미리보기 */}
+            <div className="flex flex-wrap gap-4 mb-4">
+              {newImagePreviews.map((preview, index) => (
+                <div key={index} className="relative w-24 h-24">
+                  <img src={preview} alt={`미리보기 ${index + 1}`} className="w-full h-full object-cover rounded-md" />
+                  <button type="button" onClick={() => handleRemoveNewImage(index)} className="absolute top-0 right-0 bg-red-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-xs">X</button>
+                </div>
+              ))}
+            </div>
+            {/* 파일 선택 버튼 */}
+            <input type="file" multiple onChange={handleFileChange} accept="image/*" className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100" />
+        </div>
       </div>
-
-      <div>
-        <label
-          htmlFor="content"
-          className="block text-sm font-medium text-gray-700"
-        >
-          상세 설명
-        </label>
-        <textarea
-          id="content"
-          rows={6}
-          {...register("content", { required: "상세 설명은 필수입니다." })}
-          className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
-        />
-        {errors.content && (
-          <p className="text-sm text-red-600 mt-1">{errors.content.message}</p>
-        )}
-      </div>
+      {/* --- 끝: 이미지 업로드 섹션 --- */}
 
       {isEdit && (
         <div>
-          <label
-            htmlFor="status"
-            className="block text-sm font-medium text-gray-700"
-          >
-            판매 상태
-          </label>
-          <select
-            id="status"
-            {...register("status")}
-            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
-          >
+          <label htmlFor="status" className="block text-sm font-medium text-gray-700">판매 상태</label>
+          <select id="status" {...register("status")} className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" >
             <option value="FOR_SALE">판매중</option>
             <option value="RESERVED">예약중</option>
             <option value="SOLD_OUT">판매완료</option>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,6 +4,13 @@ export interface User {
   profileImageUrl: string;
 }
 
+// 상품 이미지 타입을 정의합니다.
+export interface ProductImage {
+  id: number;
+  imageUrl: string;
+  displayOrder: number;
+}
+
 export interface Product {
   id: number;
   title: string;
@@ -14,8 +21,11 @@ export interface Product {
   updatedAt?: string;
   user: User;
 
-  // user 객체 대신 사용자 정보를 직접 포함하도록 수정
+  // 사용자 정보 직접 포함
   userUid: string;
   userNickname: string;
   userProfileImageUrl: string;
+
+  // 상품 이미지 목록을 추가합니다.
+  images: ProductImage[];
 }


### PR DESCRIPTION
## 📝 변경 사항 (Changes)

상품 이미지 등록 및 수정 기능을 구현했습니다. 이제 사용자는 상품을 등록하거나 수정할 때 여러 이미지를 업로드하고, 기존 이미지를 선택적으로 삭제하며, 상품 상세 페이지에서 이미지를 확인할 수 있습니다.

주요 구현 내용:

**프론트엔드**
- ProductForm 컴포넌트에 이미지 다중 선택, 미리보기, 삭제 기능 추가
- 상품 등록/수정 시 FormData를 사용하여 이미지 파일과 JSON 데이터를 함께 전송
- 상품 목록 및 상세 페이지에 이미지 갤러리 구현

**백엔드**
- ProductController가 multipart/form-data 요청을 처리하도록 수정
- S3UploadService를 통해 Cloudflare R2에 이미지 업로드 및 삭제 로직 구현
- R2 버킷을 공개 설정하고, 브라우저에서 접근 가능한 공개 URL을 응답하도록 수정
- API 응답 DTO(ProductResponse)에 이미지 목록을 포함

## 🔍 관련 이슈 (Related Issue)

Resolves #5

## ✔️ 테스트 방법 (How to Test)

**사전 준비:**
1.  백엔드, 프론트엔드 서버를 모두 실행합니다.
2.  테스트에 사용할 이미지 파일을 2~3개 준비합니다.

**테스트 1: 신규 상품 등록**
1.  로그인 후 `/products/new` 페이지로 이동합니다.
2.  상품명, 가격, 상세 설명을 모두 입력합니다.
3.  '파일 선택' 버튼을 눌러 준비한 이미지 2개를 한 번에 선택합니다.
4.  이미지 미리보기가 정상적으로 표시되는지 확인합니다.
5.  '등록하기' 버튼을 클릭합니다.
6.  상품 목록 페이지(`/products`)로 이동하고, 방금 등록한 상품이 첫 번째 이미지와 함께 잘 보이는지 확인합니다.
7.  등록된 상품을 클릭하여 상세 페이지로 이동했을 때, 모든 정보와 이미지 갤러리가 올바르게 표시되는지 확인합니다.
8.  (선택) Cloudflare R2 대시보드에서 `product-images` 폴더에 파일이 잘 업로드되었는지 확인합니다.

**테스트 2: 상품 정보 및 이미지 수정**
1.  테스트 1에서 생성한 상품의 상세 페이지로 이동하여 '수정하기' 버튼을 클릭합니다.
2.  상품명과 가격을 다른 내용으로 변경합니다.
3.  기존 이미지 2개 중 1개의 미리보기 우측 상단의 'X' 버튼을 눌러 삭제합니다.
4.  '파일 선택' 버튼으로 새로운 이미지 1개를 추가합니다.
5.  '수정하기' 버튼을 클릭합니다.
6.  상품 상세 페이지로 돌아왔을 때, 변경된 상품명과 가격, 그리고 수정된 이미지(기존 1개 + 새로운 1개)가 올바르게 표시되는지 확인합니다.
7.  (선택) Cloudflare R2 대시보드에서 삭제된 이미지는 사라지고, 새로 추가한 이미지가 업로드되었는지 확인합니다.

**테스트 3: 상품 삭제**
1.  수정한 상품의 상세 페이지에서 '삭제하기' 버튼을 클릭합니다.
2.  "정말로 삭제하시겠습니까?" 확인 창에서 '확인'을 누릅니다.
3.  상품 목록 페이지로 이동하고, 해당 상품이 목록에서 사라졌는지 확인합니다.
4.  (선택) Cloudflare R2 대시보드에서 관련 이미지가 모두 삭제되었는지 확인합니다.